### PR TITLE
fix: set #nickname null as the default value

### DIFF
--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -65,18 +65,21 @@ class GuildMember extends Base {
      * @type {boolean}
      */
     this.deleted = false;
+    
+    /**
+     * The nickname of this member, if they have one
+     * @type {?string}
+     * @name GuildMember#nickname
+     */
+    this.nickname = null;
 
     this._roles = [];
     if (data) this._patch(data);
   }
 
   _patch(data) {
-    /**
-     * The nickname of this member, if they have one
-     * @type {?string}
-     * @name GuildMember#nickname
-     */
-    if (typeof data.nick !== 'undefined') this.nickname = data.nick;
+
+    if (typeof data.nick === 'string') this.nickname = data.nick;
 
     if (data.joined_at) this.joinedTimestamp = new Date(data.joined_at).getTime();
     if (data.premium_since) this.premiumSinceTimestamp = new Date(data.premium_since).getTime();


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

* closes #4640
According to #4640, the `.nickname` property of a guildmember returns `undefined` instead of `null` if not present.

This might be due to the way the library currently handles and assigns the initial `data` payload received from Discord itself.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
